### PR TITLE
Remove useless link

### DIFF
--- a/content/1.getting-started/1.Installation.md
+++ b/content/1.getting-started/1.Installation.md
@@ -20,6 +20,3 @@ Install the package with:
 ```bash
 composer require lomkit/laravel-access-control
 ```
-
-### Setting up your first project
-[Have a look at our first setup section](/#first-setup)


### PR DESCRIPTION
Remove a "getting started" link because there is no getting started section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the installation documentation by removing an introductory heading and navigation link, retaining only the installation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->